### PR TITLE
Refactor patterns to enum PatternSpecific and struct Pattern

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,9 @@ fn main()
     middle_sphere_material.color = create_color(0.1, 1.0, 0.5);
     middle_sphere_material.diffuse = 0.7;
     middle_sphere_material.specular = 0.3;
-    let middle_sphere_pattern = Pattern::new_stripe_pattern(create_color(0.0, 0.5, 0.5),
+    let mut middle_sphere_pattern = Pattern::new_checker_pattern(create_color(0.0, 0.5, 0.5),
         create_color(0.0, 0.8, 0.8));
+    middle_sphere_pattern.set_pattern_transform(Matrix::scaling(0.5, 0.5, 0.5));
     middle_sphere_material.pattern = Some(middle_sphere_pattern);
     middle_sphere.set_material(middle_sphere_material);
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -29,13 +29,10 @@ impl Material
     {
         let color = match &self.pattern
         {
-            Some(p) => match p
+            Some(p) => match p.get_common()
             {
-                Pattern::StripePattern(s) => s.stripe_at_object(object, point),
-                Pattern::TestPattern(t) => t.pattern_at(point),
-                Pattern::GradientPattern(_g) => p.pattern_at_shape(object, point),
-                Pattern::RingPattern(_r) => p.pattern_at_shape(object, point),
-                Pattern::CheckerPattern(_c) => p.pattern_at_shape(object, point),
+                PatternCommon::TestPattern(t) => t.pattern_at(point),
+                _ => p.pattern_at_shape(object, point),
             },
             None => self.color,
         };

--- a/src/material.rs
+++ b/src/material.rs
@@ -29,9 +29,9 @@ impl Material
     {
         let color = match &self.pattern
         {
-            Some(p) => match p.get_common()
+            Some(p) => match p.get_specific()
             {
-                PatternCommon::TestPattern(t) => t.pattern_at(point),
+                PatternSpecific::TestPattern(t) => t.pattern_at(point),
                 _ => p.pattern_at_shape(object, point),
             },
             None => self.color,

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -9,24 +9,13 @@ pub struct StripePattern
 {
     pub a: Tuple,
     pub b: Tuple,
-    pub transform: Matrix,
 }
 
 impl StripePattern
 {
     pub fn new(a: Tuple, b: Tuple) -> StripePattern
     {
-        StripePattern{a: a, b: b, transform: Matrix::identity(4)}
-    }
-
-    pub fn get_transform(&self) -> Matrix
-    {
-        self.transform.clone()
-    }
-
-    pub fn set_transform(&mut self, transform: Matrix)
-    {
-        self.transform = transform;
+        StripePattern{a: a, b: b}
     }
 
     pub fn stripe_at(&self, point: Tuple) -> Tuple
@@ -46,36 +35,18 @@ impl StripePattern
     {
         self.stripe_at(point)
     }
-
-    pub fn stripe_at_object(&self, object: Shape, world_point: Tuple) -> Tuple
-    {
-        let object_point = object.get_transform().inverse().multiply_tuple(world_point);
-        let pattern_point = self.transform.inverse().multiply_tuple(object_point);
-        self.stripe_at(pattern_point)
-    }
 }
 
 #[derive(Clone, Debug)]
 pub struct TestPattern
 {
-    pub transform: Matrix,
 }
 
 impl TestPattern
 {
     pub fn new() -> TestPattern
     {
-        TestPattern{transform: Matrix::identity(4)}
-    }
-
-    pub fn get_transform(&self) -> Matrix
-    {
-        self.transform.clone()
-    }
-
-    pub fn set_transform(&mut self, transform: Matrix)
-    {
-        self.transform = transform;
+        TestPattern{}
     }
 
     pub fn pattern_at(&self, point: Tuple) -> Tuple
@@ -90,24 +61,13 @@ pub struct GradientPattern
 {
     pub a: Tuple,
     pub b: Tuple,
-    pub transform: Matrix,
 }
 
 impl GradientPattern
 {
     pub fn new(a: Tuple, b: Tuple) -> GradientPattern
     {
-        GradientPattern{a: a, b: b, transform: Matrix::identity(4)}
-    }
-
-    pub fn get_transform(&self) -> Matrix
-    {
-        self.transform.clone()
-    }
-
-    pub fn set_transform(&mut self, transform: Matrix)
-    {
-        self.transform = transform;
+        GradientPattern{a: a, b: b}
     }
 
     pub fn pattern_at(&self, point: Tuple) -> Tuple
@@ -124,24 +84,13 @@ pub struct RingPattern
 {
     pub a: Tuple,
     pub b: Tuple,
-    pub transform: Matrix,
 }
 
 impl RingPattern
 {
     pub fn new(a: Tuple, b: Tuple) -> RingPattern
     {
-        RingPattern{a: a, b: b, transform: Matrix::identity(4)}
-    }
-
-    pub fn get_transform(&self) -> Matrix
-    {
-        self.transform.clone()
-    }
-
-    pub fn set_transform(&mut self, transform: Matrix)
-    {
-        self.transform = transform;
+        RingPattern{a: a, b: b}
     }
 
     pub fn pattern_at(&self, point: Tuple) -> Tuple
@@ -164,24 +113,13 @@ pub struct CheckerPattern
 {
     pub a: Tuple,
     pub b: Tuple,
-    pub transform: Matrix,
 }
 
 impl CheckerPattern
 {
     pub fn new(a: Tuple, b: Tuple) -> CheckerPattern
     {
-        CheckerPattern{a: a, b: b, transform: Matrix::identity(4)}
-    }
-
-    pub fn get_transform(&self) -> Matrix
-    {
-        self.transform.clone()
-    }
-
-    pub fn set_transform(&mut self, transform: Matrix)
-    {
-        self.transform = transform;
+        CheckerPattern{a: a, b: b}
     }
 
     pub fn pattern_at(&self, point: Tuple) -> Tuple
@@ -199,9 +137,8 @@ impl CheckerPattern
     }
 }
 
-
 #[derive(Clone, Debug)]
-pub enum Pattern
+pub enum PatternCommon
 {
     StripePattern(StripePattern),
     TestPattern(TestPattern),
@@ -210,68 +147,81 @@ pub enum Pattern
     CheckerPattern(CheckerPattern),
 }
 
+#[derive(Clone, Debug)]
+pub struct Pattern
+{
+    transform: Matrix,
+    common: PatternCommon,
+}
+
 impl Pattern
 {
+    pub fn get_transform(&self) -> Matrix
+    {
+        self.transform.clone()
+    }
+
+    pub fn set_transform(&mut self, transform: Matrix)
+    {
+        self.transform = transform;
+    }
+
+    pub fn get_common(&self) -> PatternCommon
+    {
+        self.common.clone()
+    }
+
     pub fn new_stripe_pattern(a: Tuple, b: Tuple) -> Pattern
     {
-        Pattern::StripePattern(StripePattern::new(a, b))
+        Pattern{transform: Matrix::identity(4),
+            common: PatternCommon::StripePattern(StripePattern::new(a, b))}
     }
 
     pub fn test_pattern() -> Pattern
     {
-        Pattern::TestPattern(TestPattern::new())
+        Pattern{transform: Matrix::identity(4),
+            common: PatternCommon::TestPattern(TestPattern::new())}
     }
 
     pub fn new_gradient_pattern(a: Tuple, b: Tuple) -> Pattern
     {
-        Pattern::GradientPattern(GradientPattern::new(a, b))
+        Pattern{transform: Matrix::identity(4),
+            common: PatternCommon::GradientPattern(GradientPattern::new(a, b))}
     }
 
     pub fn new_ring_pattern(a: Tuple, b: Tuple) -> Pattern
     {
-        Pattern::RingPattern(RingPattern::new(a, b))
+        Pattern{transform: Matrix::identity(4),
+            common: PatternCommon::RingPattern(RingPattern::new(a, b))}
     }
 
     pub fn new_checker_pattern(a: Tuple, b: Tuple) -> Pattern
     {
-        Pattern::CheckerPattern(CheckerPattern::new(a, b))
+        Pattern{transform: Matrix::identity(4),
+            common: PatternCommon::CheckerPattern(CheckerPattern::new(a, b))}
     }
 
     pub fn get_pattern_transform(&self) -> Matrix
     {
-        match &self
-        {
-            Pattern::StripePattern(s) => s.get_transform(),
-            Pattern::TestPattern(t) => t.get_transform(),
-            Pattern::GradientPattern(g) => g.get_transform(),
-            Pattern::RingPattern(r) => r.get_transform(),
-            Pattern::CheckerPattern(c) => c.get_transform(),
-        }
+        self.transform.clone()
     }
 
     pub fn set_pattern_transform(&mut self, transform: Matrix)
     {
-        match self
-        {
-            Pattern::StripePattern(s) => s.set_transform(transform),
-            Pattern::TestPattern(t) => t.set_transform(transform),
-            Pattern::GradientPattern(g) => g.set_transform(transform),
-            Pattern::RingPattern(r) => r.set_transform(transform),
-            Pattern::CheckerPattern(c) => c.set_transform(transform),
-        }
+        self.transform = transform;
     }
 
     pub fn pattern_at_shape(&self, shape: Shape, world_point: Tuple) -> Tuple
     {
         let object_point = shape.get_transform().inverse().multiply_tuple(world_point);
         let pattern_point = self.get_pattern_transform().inverse().multiply_tuple(object_point);
-        match self
+        match &self.common
         {
-            Pattern::StripePattern(s) => s.pattern_at(pattern_point),
-            Pattern::TestPattern(t) => t.pattern_at(pattern_point),
-            Pattern::GradientPattern(g) => g.pattern_at(pattern_point),
-            Pattern::RingPattern(r) => r.pattern_at(pattern_point),
-            Pattern::CheckerPattern(c) => c.pattern_at(pattern_point),
+            PatternCommon::StripePattern(s) => s.pattern_at(pattern_point),
+            PatternCommon::TestPattern(t) => t.pattern_at(pattern_point),
+            PatternCommon::GradientPattern(g) => g.pattern_at(pattern_point),
+            PatternCommon::RingPattern(r) => r.pattern_at(pattern_point),
+            PatternCommon::CheckerPattern(c) => c.pattern_at(pattern_point),
         }
     }
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -138,7 +138,7 @@ impl CheckerPattern
 }
 
 #[derive(Clone, Debug)]
-pub enum PatternCommon
+pub enum PatternSpecific
 {
     StripePattern(StripePattern),
     TestPattern(TestPattern),
@@ -151,44 +151,44 @@ pub enum PatternCommon
 pub struct Pattern
 {
     transform: Matrix,
-    common: PatternCommon,
+    specific: PatternSpecific,
 }
 
 impl Pattern
 {
-    pub fn get_common(&self) -> PatternCommon
+    pub fn get_specific(&self) -> PatternSpecific
     {
-        self.common.clone()
+        self.specific.clone()
     }
 
     pub fn new_stripe_pattern(a: Tuple, b: Tuple) -> Pattern
     {
         Pattern{transform: Matrix::identity(4),
-            common: PatternCommon::StripePattern(StripePattern::new(a, b))}
+            specific: PatternSpecific::StripePattern(StripePattern::new(a, b))}
     }
 
     pub fn test_pattern() -> Pattern
     {
         Pattern{transform: Matrix::identity(4),
-            common: PatternCommon::TestPattern(TestPattern::new())}
+            specific: PatternSpecific::TestPattern(TestPattern::new())}
     }
 
     pub fn new_gradient_pattern(a: Tuple, b: Tuple) -> Pattern
     {
         Pattern{transform: Matrix::identity(4),
-            common: PatternCommon::GradientPattern(GradientPattern::new(a, b))}
+            specific: PatternSpecific::GradientPattern(GradientPattern::new(a, b))}
     }
 
     pub fn new_ring_pattern(a: Tuple, b: Tuple) -> Pattern
     {
         Pattern{transform: Matrix::identity(4),
-            common: PatternCommon::RingPattern(RingPattern::new(a, b))}
+            specific: PatternSpecific::RingPattern(RingPattern::new(a, b))}
     }
 
     pub fn new_checker_pattern(a: Tuple, b: Tuple) -> Pattern
     {
         Pattern{transform: Matrix::identity(4),
-            common: PatternCommon::CheckerPattern(CheckerPattern::new(a, b))}
+            specific: PatternSpecific::CheckerPattern(CheckerPattern::new(a, b))}
     }
 
     pub fn get_pattern_transform(&self) -> Matrix
@@ -205,13 +205,13 @@ impl Pattern
     {
         let object_point = shape.get_transform().inverse().multiply_tuple(world_point);
         let pattern_point = self.get_pattern_transform().inverse().multiply_tuple(object_point);
-        match &self.common
+        match &self.specific
         {
-            PatternCommon::StripePattern(s) => s.pattern_at(pattern_point),
-            PatternCommon::TestPattern(t) => t.pattern_at(pattern_point),
-            PatternCommon::GradientPattern(g) => g.pattern_at(pattern_point),
-            PatternCommon::RingPattern(r) => r.pattern_at(pattern_point),
-            PatternCommon::CheckerPattern(c) => c.pattern_at(pattern_point),
+            PatternSpecific::StripePattern(s) => s.pattern_at(pattern_point),
+            PatternSpecific::TestPattern(t) => t.pattern_at(pattern_point),
+            PatternSpecific::GradientPattern(g) => g.pattern_at(pattern_point),
+            PatternSpecific::RingPattern(r) => r.pattern_at(pattern_point),
+            PatternSpecific::CheckerPattern(c) => c.pattern_at(pattern_point),
         }
     }
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -156,16 +156,6 @@ pub struct Pattern
 
 impl Pattern
 {
-    pub fn get_transform(&self) -> Matrix
-    {
-        self.transform.clone()
-    }
-
-    pub fn set_transform(&mut self, transform: Matrix)
-    {
-        self.transform = transform;
-    }
-
     pub fn get_common(&self) -> PatternCommon
     {
         self.common.clone()


### PR DESCRIPTION
Create `enum PatternSpecific` with functions specific to each type of pattern.

Create `struct Pattern` containing common functions for patterns, plus an `enum PatternSpecific`.