### PR TITLE
Refactor Shape into struct Shape and enum ShapeSpecific

### DIFF
--- a/src/cube.rs
+++ b/src/cube.rs
@@ -13,53 +13,21 @@ use crate::shape::*;
 #[derive(Clone, Debug)]
 pub struct Cube
 {
-    id: i32,
-    transform: Matrix,
-    material: Material,
-    saved_ray: Ray,
 }
 
 // An axis aligned bounding box from -1 to +1 on each axis
 impl Cube
 {
-    pub fn get_local_transform(&self) -> Matrix
-    {
-        self.transform.clone()
-    }
-
-    pub fn set_local_transform(&mut self, transform: Matrix)
-    {
-        self.transform = transform;
-    }
-
-    pub fn get_local_material(&self) -> Material
-    {
-        self.material.clone()
-    }
-
-    pub fn set_local_material(&mut self, material: Material)
-    {
-        self.material = material;
-    }
-
-    pub fn get_id(&self) -> i32
-    {
-        self.id
-    }
 }
 
 impl Cube
 {
-    pub fn new(id: i32) -> Self
+    pub fn new() -> Self
     {
-        let zero_point = create_point(0.0, 0.0, 0.0);
-        let zero_vector = create_vector(0.0, 0.0, 0.0);
-        Cube{id: id, transform: Matrix::identity(4),
-            material: Material::new(),
-            saved_ray: Ray::new(zero_point, zero_vector)}
+        Cube{}
     }
 
-    fn check_axis(&mut self, origin: f64, direction: f64) -> (f64, f64)
+    fn check_axis(&self, origin: f64, direction: f64) -> (f64, f64)
     {
         let tmin_numerator = -1.0 - origin;
         let tmax_numerator = 1.0 - origin;
@@ -115,7 +83,7 @@ impl Cube
         n
     }
 
-    pub fn local_intersect(&mut self, ray: Ray) -> Vec<f64>
+    pub fn local_intersect(&self, ray: Ray) -> Vec<f64>
     {
         let (xtmin, xtmax) = self.check_axis(ray.origin.get_vec()[0],
             ray.direction.get_vec()[0]);
@@ -133,16 +101,6 @@ impl Cube
         }
 
         return vec![tmin, tmax];
-    }
-
-    pub fn local_get_saved_ray(&self) -> Ray
-    {
-        self.saved_ray
-    }
-
-    pub fn local_set_saved_ray(&mut self, saved_ray: Ray)
-    {
-        self.saved_ray = saved_ray;
     }
 
     pub fn local_normal_at(&self, point: Tuple) -> Tuple
@@ -165,19 +123,11 @@ impl Cube
     }
 }
 
-impl PartialEq for Cube
-{
-    fn eq(&self, other: &Self) -> bool
-    {
-        self.id == other.id
-    }
-}
-
 impl fmt::Display for Cube
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result
     {
-        write!(f, "cube {}", self.id)
+        write!(f, "cube")
     }
 }
 
@@ -190,7 +140,7 @@ mod tests
     fn test_cubes_feature1()
     {
         // p.168 Scenario: A ray intersects a cube
-        let mut c1 = Cube::new(1);
+        let c1 = Cube::new();
         let origins1 = vec![create_point(5.0, 0.5, 0.0),
             create_point(-5.0, 0.5, 0.0),
             create_point(0.5, 5.0, 0.0),
@@ -222,7 +172,7 @@ mod tests
     fn test_cubes_feature2()
     {
         // p.172 Scenario: A ray misses a cube
-        let mut c2 = Cube::new(2);
+        let c2 = Cube::new();
         let origins2 = vec![create_point(-2.0, 0.0, 0.0),
             create_point(0.0, -2.0, 0.0),
             create_point(0.0, 0.0, -2.0),
@@ -248,7 +198,7 @@ mod tests
     fn test_cubes_feature3()
     {
         // p.172 Scenario: The normal on the surface of a cube
-        let mut c3 = Cube::new(3);
+        let c3 = Cube::new();
         let points3 = vec![create_point(1.0, 0.5, -0.8),
             create_point(-1.0, -0.2, 0.9),
             create_point(-0.4, 1.0, -0.1),

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -9,56 +9,20 @@ use crate::material::*;
 use crate::ray::*;
 use crate::shape::*;
 
+// A plane in x and z axes, passing through the origin
 #[derive(Clone, Debug)]
 pub struct Plane
 {
-    id: i32,
-    transform: Matrix,
-    material: Material,
-    saved_ray: Ray,
-}
-
-// A plane in x and z axes, passing through the origin
-impl Plane
-{
-    pub fn get_local_transform(&self) -> Matrix
-    {
-        self.transform.clone()
-    }
-
-    pub fn set_local_transform(&mut self, transform: Matrix)
-    {
-        self.transform = transform;
-    }
-
-    pub fn get_local_material(&self) -> Material
-    {
-        self.material.clone()
-    }
-
-    pub fn set_local_material(&mut self, material: Material)
-    {
-        self.material = material;
-    }
-
-    pub fn get_id(&self) -> i32
-    {
-        self.id
-    }
 }
 
 impl Plane
 {
-    pub fn new(id: i32) -> Self
+    pub fn new() -> Self
     {
-        let zero_point = create_point(0.0, 0.0, 0.0);
-        let zero_vector = create_vector(0.0, 0.0, 0.0);
-        Plane{id: id, transform: Matrix::identity(4),
-            material: Material::new(),
-            saved_ray: Ray::new(zero_point, zero_vector)}
+        Plane{}
     }
 
-    pub fn local_intersect(&mut self, ray: Ray) -> Vec<f64>
+    pub fn local_intersect(&self, ray: Ray) -> Vec<f64>
     {
         if ray.direction.get_vec()[1].abs() < EPSILON
         {
@@ -69,27 +33,9 @@ impl Plane
         return vec![t];
     }
 
-    pub fn local_get_saved_ray(&self) -> Ray
-    {
-        self.saved_ray
-    }
-
-    pub fn local_set_saved_ray(&mut self, saved_ray: Ray)
-    {
-        self.saved_ray = saved_ray;
-    }
-
     pub fn local_normal_at(&self, _local_point: Tuple) -> Tuple
     {
         create_vector(0.0, 1.0, 0.0)
-    }
-}
-
-impl PartialEq for Plane
-{
-    fn eq(&self, other: &Self) -> bool
-    {
-        self.id == other.id
     }
 }
 
@@ -97,7 +43,7 @@ impl fmt::Display for Plane
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result
     {
-        write!(f, "plane {}", self.id)
+        write!(f, "plane")
     }
 }
 
@@ -110,7 +56,7 @@ mod tests
     fn test_planes_feature()
     {
         // p.122 Scenario: The normal of a plane is constant everywhere
-        let p1 = Plane::new(1);
+        let p1 = Plane::new();
         let n11 = p1.local_normal_at(create_point(0.0, 0.0, 0.0));
         let n12 = p1.local_normal_at(create_point(10.0, 0.0, -10.0));
         let n13 = p1.local_normal_at(create_point(-5.0, 0.0, 150.0));
@@ -119,26 +65,26 @@ mod tests
         assert_eq!(n13, create_vector(0.0, 1.0, 0.0));
 
         // p.123 Scenario: Intersect with a ray parallel to the plane
-        let mut p2 = Plane::new(2);
+        let p2 = Plane::new();
         let r2 = Ray::new(create_point(0.0, 10.0, 0.0), create_vector(0.0, 0.0, 1.0));
         let xs2 = p2.local_intersect(r2);
         assert_eq!(xs2.len(), 0);
 
         // p.123 Scenario: Intersect with a coplanar ray
-        let mut p3 = Plane::new(3);
+        let p3 = Plane::new();
         let r3 = Ray::new(create_point(0.0, 0.0, 0.0), create_vector(0.0, 0.0, 1.0));
         let xs3 = p3.local_intersect(r3);
         assert_eq!(xs3.len(), 0);
 
         // p.123 Scenario: A ray intersecting a plane from above
-        let mut p4 = Plane::new(4);
+        let p4 = Plane::new();
         let r4 = Ray::new(create_point(0.0, 1.0, 0.0), create_vector(0.0, -1.0, 0.0));
         let xs4 = p4.local_intersect(r4);
         assert_eq!(xs4.len(), 1);
         assert!(fuzzy_equal(xs4[0], 1.0));
 
         // p.123 Scenario: A ray intersecting a plane from below
-        let mut p5 = Plane::new(5);
+        let p5 = Plane::new();
         let r5 = Ray::new(create_point(0.0, -1.0, 0.0), create_vector(0.0, 1.0, 0.0));
         let xs5 = p5.local_intersect(r5);
         assert_eq!(xs5.len(), 1);

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -10,52 +10,16 @@ use crate::shape::*;
 #[derive(Clone, Debug)]
 pub struct Sphere
 {
-    id: i32,
-    transform: Matrix,
-    material: Material,
-    saved_ray: Ray,
 }
 
 impl Sphere
 {
-    pub fn get_local_transform(&self) -> Matrix
+    pub fn new() -> Self
     {
-        self.transform.clone()
+        Sphere{}
     }
 
-    pub fn set_local_transform(&mut self, transform: Matrix)
-    {
-        self.transform = transform;
-    }
-
-    pub fn get_local_material(&self) -> Material
-    {
-        self.material.clone()
-    }
-
-    pub fn set_local_material(&mut self, material: Material)
-    {
-        self.material = material;
-    }
-
-    pub fn get_id(&self) -> i32
-    {
-        self.id
-    }
-}
-
-impl Sphere
-{
-    pub fn new(id: i32) -> Self
-    {
-        let zero_point = create_point(0.0, 0.0, 0.0);
-        let zero_vector = create_vector(0.0, 0.0, 0.0);
-        Sphere{id: id, transform: Matrix::identity(4),
-            material: Material::new(),
-            saved_ray: Ray::new(zero_point, zero_vector)}
-    }
-
-    pub fn local_intersect(&mut self, ray: Ray) -> Vec<f64>
+    pub fn local_intersect(&self, ray: Ray) -> Vec<f64>
     {
         let ray2 = ray;
 
@@ -79,16 +43,6 @@ impl Sphere
         return vec![t1, t2];
     }
 
-    pub fn local_get_saved_ray(&self) -> Ray
-    {
-        self.saved_ray
-    }
-
-    pub fn local_set_saved_ray(&mut self, saved_ray: Ray)
-    {
-        self.saved_ray = saved_ray;
-    }
-
     pub fn local_normal_at(&self, local_point: Tuple) -> Tuple
     {
         let local_normal = local_point.sub(create_point(0.0, 0.0, 0.0));
@@ -96,19 +50,11 @@ impl Sphere
     }
 }
 
-impl PartialEq for Sphere
-{
-    fn eq(&self, other: &Self) -> bool
-    {
-        self.id == other.id
-    }
-}
-
 impl fmt::Display for Sphere
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result
     {
-        write!(f, "sphere {}", self.id)
+        write!(f, "sphere")
     }
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -335,7 +335,7 @@ mod tests
     fn test_world_refraction_feature()
     {
         // p.155 Scenario: The refracted color with an opaque surface
-        let mut world1 = World::default_world();
+        let world1 = World::default_world();
         let shape1 = world1.objects[0].clone();
         let r1 = Ray::new(create_point(0.0, 0.0, -5.0), create_vector(0.0, 0.0, 1.0));
         let i11 = Intersection::new(4.0, shape1.clone());
@@ -350,7 +350,7 @@ mod tests
         assert_eq!(color2, create_color(0.0, 0.0, 0.0));
 
         // p.157 Scenario: The refracted color under total internal reflection
-        let mut world3 = World::default_world();
+        let world3 = World::default_world();
         let shape3 = world3.objects[0].clone();
         let mut material3 = shape3.get_material();
         material3.transparency = 1.0;


### PR DESCRIPTION
Recreate struct Shape with fields common to all shapes.

Create enum ShapeSpecific with fields and functions specific to each type of shape.

Remove mut keyword from some variables that are no longer mutable.